### PR TITLE
Altera configuração do docker compose

### DIFF
--- a/bd/docker-compose.yml
+++ b/bd/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   db:
     image: postgres:11.1-alpine
     container_name: postgres
+    restart: always
     environment:
       - POSTGRES_DB=vozativa
       - POSTGRES_USER=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
   log_server:
     build: ./bd/server/  
     container_name: log-server
+    restart: always
     volumes:
       - ./bd:/log-server/bd
       - ./bd/server/server.js:/log-server/bd/server/server.js


### PR DESCRIPTION
### Changes
- Adiciona configuração para reiniciar serviços sempre que possível a menos que o serviço tenha sido parado explicitamente via comando docker. Serviços modificados foram:
  - Banco de dados postgres para desenvolvimento
  - Servidor de logs 

### Flags
Uma maneira de testar se o serviço está tentando reiniciar quando derrubado é reiniciar a máquina. Outra maneira mais rápida é reiniciar o docker como um todo: sudo service docker restart. Depois basta checar se os serviços voltaram em docker ps.

### Related Issues
Os serviços na VM precisavam ser reiniciados manualmente após um reinício da instância. Isso diminui a robustez dos serviços.